### PR TITLE
Python3 move

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ This environment was designed to run locally, on an Ubuntu 18.04 machine. There 
 
 The following python packages are required:
 
-+pyroot
-+uproot3
-+pandas
-+numpy
-+boost-histogram
-+configparser
++ pyroot
++ uproot3
++ pandas
++ numpy
++ boost-histogram
++ configparser
 
 if you already have Python 3 working with ROOT, with the above dependences, skip to "Download Repository and Setup Restframes." If you do not, you can follow the conda environment instructions below.
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,57 @@ The following python packages are required:
 
 if you already have Python 3 working with ROOT, with the above dependences, skip to "Download Repository and Setup Restframes." If you do not, you can follow the conda environment instructions below.
 
-### Conda forge: Setting up all your needs
+### Conda-forge: Setting up all your needs
 
-### Download Repository and Setup RestFrames.
+We will use a conda environment to keep all versions in sync, and save us the headache of trying to keep ROOT up-to-date with the rest of the universe. These directions are based on Bob Hirosky's directions for the University of Virginia's 56XX computational physics courses. The reasoning behind using conda, what it is, and all the jazz is found [there](https://raw.githubusercontent.com/UVaCompPhys/PHYS56xx-setup/master/notebooks/FAQ/WorkingEnv.ipynb).
 
-## Making Topiary (Analysis Thrid Step)
+To get started, we will install minconda.
+
+```bash
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+chmod +x Miniconda3-latest-Linux-x86_64.sh
+./Miniconda3-latest-Linux-x86_64.sh
+
+```
+
+This edits your ```.bashrc``` file, so either restart your shell or ```source ~/.bashrc```. The defailt is to start a ```(base)``` conda envoriment upon startup, as indicated from your now altered PS1. I despise this, so to turn off this startup feature, execute
+
+```conda config --set auto_activate_base false```
+
+Now we can begin setting up the useful environment. We will be using the conda-forge repository as the base.
+
+```bash
+conda config --add channels conda-forge
+conda config --show channels
+conda config --set channel_priority strict
+```
+
+Setup the conda environment to run this analysis.
+
+```bash
+conda create -n ZpAnomalon
+conda env list
+conda activate ZpAnomalon
+```
+
+To deactivate the environment, simply use ```conda deactivate ZpAnomalon```.
+
+Install the packages.
+
+```bash
+conda install --yes scipy matplotlib seaborn sympy scikit-learn
+conda install --yes root
+conda install -c conda-forge pandas
+conda install -c conda-forge uproot
+conda install -c conda-forge uproot3
+conda install -c conda-forge configparser
+conda install -c conda-forge boost-histogram
+```
+To see what you have installed, ```conda list```. The python environment is ready. Proceed to the next section to implement Restframes.
+
+### Download Repository and Setup RestFrames
+
+## Making Topiary (Analysis Third Step)
 
 As stated in the intro, the third step in our analysis chain is c++ TMakeClass analyzer used to trim the skims produced by the trimmer in trimmerShed, do the RJR calculation, and flatten the trees for easier Pandas dataframe use.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ZpAnomalon Analysis - RJR to Plots
 
-This is the repo of the third, fourth, and plotting  steps of the ZpAnomalon Analysis. In this analysis, We are using Recrusive Jigsaw Reconstruction to generate the mass estimators of each daughter particle in the Z' decay chain. This calculcation is done with the Restframes package, whose installation details are outlined below. A c++ TMakeClass analyzer is used to calculate the RJR quantiies, and flatten the output trees from trimmerShed. The flattened trees are passed to a python native dataframe based analyzer, which creates the analysis object hisotgrams.
+This is the repo of the third, fourth, and plotting  steps of the ZpAnomalon Analysis. In this analysis, We are using Recrusive Jigsaw Reconstruction to generate the mass estimators of each daughter particle in the Z' decay chain. This calculcation is done with the Restframes package, whose installation details are outlined below. A c++ TMakeClass analyzer is used to calculate the RJR quantiies, and flatten the output trees from [trimmerShed](https://github.com/gracecummings/trimmerShed). The flattened trees are passed to a python native dataframe based analyzer, which creates the analysis object hisotgrams.
 
 ## Setting up the analysis environment
 
@@ -19,7 +19,7 @@ if you already have Python 3 working with ROOT, with the above dependences, skip
 
 ### Conda-forge: Setting up all your needs
 
-We will use a conda environment to keep all versions in sync, and save us the headache of trying to keep ROOT up-to-date with the rest of the universe. These directions are based on Bob Hirosky's directions for the University of Virginia's 56XX computational physics courses. The reasoning behind using conda, what it is, and all the jazz is found [there](https://raw.githubusercontent.com/UVaCompPhys/PHYS56xx-setup/master/notebooks/FAQ/WorkingEnv.ipynb).
+We will use a conda environment to keep all versions in sync, and save us the headache of trying to keep ROOT up-to-date with the rest of the universe. These directions are based on Bob Hirosky's directions for the University of Virginia's 56XX computational physics courses. The reasoning behind using conda, what it is, and all that jazz is found [there](https://raw.githubusercontent.com/UVaCompPhys/PHYS56xx-setup/master/notebooks/FAQ/WorkingEnv.ipynb).
 
 To get started, we will install minconda.
 
@@ -67,9 +67,43 @@ To see what you have installed, ```conda list```. The python environment is read
 
 ### Download Repository and Setup RestFrames
 
+Download this analysis repository. I would recommend forking it, with the icon in the top left. Detailed directions on how to fork, and sync with this repo, can be found in the [Github Docs](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo). Ther eis no special setup script or compiling. Once you have the repository setup locally,
+
+```bash
+cd ZpAnomalonAnalysisUproot
+```
+
+We use the [RestFrames](http://restframes.com/) package to calculate the mass esitmators of the Z' cascade decay. Make sure you have you conda environment activated, to compile Restframes with the appropriate ROOT version. I install RestFrames in the repo directory, to make it easy to keep track, and to avoid possible conflicts on my larger system.
+
+```bash
+git clone https://github.com/crogan/RestFrames RestFrames
+cd RestFrames
+./configure --prefix=$PWD
+make
+make install
+```
+
 ## Making Topiary (Analysis Third Step)
 
-As stated in the intro, the third step in our analysis chain is c++ TMakeClass analyzer used to trim the skims produced by the trimmer in trimmerShed, do the RJR calculation, and flatten the trees for easier Pandas dataframe use.
+As stated in the intro, the third step in our analysis chain is c++ TMakeClass analyzer used to trim the skims produced by the trimmer in trimmerShed, do the RJR calculation, and flatten the trees for easier Pandas dataframe use. This is done with a ROOT macro, exectued via a python script. To call RestFrames libraries from a ROOT macro, you must first source the setup script. From the ```ZpAnomalonAnalysisUproot``` directory,
+
+```bash
+source RestFrames/setup_RestFrames.sh
+```
+
+Currently, these scripts are designed to run locally, with the [trimmerShed](https://github.com/gracecummings/trimmerShed) produced skims stored somewhere on a local machine. Ideally, this step will be combined with the trimmerShed step, but that is for the future. The path can be set by changing
+
+```python
+inputs  = glob.glob("../dataHandling/"+year+"/"+samp+"*.root")
+```
+
+in ```runTopiary.py``` to the correct path on your machine. An example executable command to produce a topiary is:
+
+```bash
+python runTopiary.py -s Fall17.DYJetsToLL_M-50_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8 -y 2017
+```
+
+Executables inthis framework are naming sensitive, so be sure to include the [ZpAnomalon_TreeMaker](https://github.com/gracecummings/ZpAnomalon_TreeMaker) naming conventions in the sample strings.
 
 ## Doing selections (Analysis Fourth Step)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# ZpAnomalon Analysis - RJR to Plots
+
+This is the repo of the third, fourth, and plotting  steps of the ZpAnomalon Analysis. In this analysis, We are using Recrusive Jigsaw Reconstruction to generate the mass estimators of each daughter particle in the Z' decay chain. This calculcation is done with the Restframes package, whose installation details are outlined below. A c++ TMakeClass analyzer is used to calculate the RJR quantiies, and flatten the output trees from trimmerShed. The flattened trees are passed to a python native dataframe based analyzer, which creates the analysis object hisotgrams.
+
+## Setting up the analysis environment
+
+This environment was designed to run locally, on an Ubuntu 18.04 machine. There are a lot of packages that this requries, and the below works to set this up locally. At this time, the procedures have not been vetted on the LPC, but the installation of RestFrames, and maybe the Uproot 3 versus 4 distinction, would probably be the only thing that would not work out-of-the-box.
+
+The following python packages are required:
+
++pyroot
++uproot3
++pandas
++numpy
++boost-histogram
++configparser
+
+if you already have Python 3 working with ROOT, with the above dependences, skip to "Download Repository and Setup Restframes." If you do not, you can follow the conda environment instructions below.
+
+### Conda forge: Setting up all your needs
+
+### Download Repository and Setup RestFrames.
+
+## Making Topiary (Analysis Thrid Step)
+
+As stated in the intro, the third step in our analysis chain is c++ TMakeClass analyzer used to trim the skims produced by the trimmer in trimmerShed, do the RJR calculation, and flatten the trees for easier Pandas dataframe use.
+
+## Doing selections (Analysis Fourth Step)
+
+## Other manipulations and facillitated respins
+
+In many cases, one wants to do go from new selections to plots all in one go. There is a script for that. 

--- a/TreeMakerTopiary.C
+++ b/TreeMakerTopiary.C
@@ -143,9 +143,8 @@ void TreeMakerTopiary::Loop(std::string outputFileName, float totalOriginalEvent
    string ourtrg;
    int trgidx    = -1;
    int trgval;
-   TFile * fthen;
-   TFile * fnow;
-
+   TFile * fthen = 0;
+   TFile * fnow = 0;
 
    //counters
    int counttrigpass = 0;
@@ -173,9 +172,9 @@ void TreeMakerTopiary::Loop(std::string outputFileName, float totalOriginalEvent
       }
 
       //debug
-      if (jentry == 200) {
-      break;
-      }
+      //if (jentry == 200) {
+      //break;
+      //}
 
       //Trigger decisions
       size_t pos = 0;

--- a/doCutFlow.py
+++ b/doCutFlow.py
@@ -1,5 +1,5 @@
 import subprocess
-import gecorg_py3 as go
+import gecorg as go
 import argparse
 import ROOT
 import numpy as np

--- a/doCutFlow.py
+++ b/doCutFlow.py
@@ -1,5 +1,5 @@
 import subprocess
-import gecorg as go
+import gecorg_py3 as go
 import argparse
 import ROOT
 import numpy as np
@@ -13,6 +13,7 @@ if __name__=='__main__':
     parser.add_argument("-j","--hptcut", type=float,help = "hpt cut of samples")
     parser.add_argument("-wp","--btagwp", type=float,help = "btag working point")
     parser.add_argument("-date","--date",help="date folder with plots to stack")
+    parser.add_argument("-y","--year", type=float,help = "year of samples eg. 2017 -> 17")
     args = parser.parse_args()
 
     #Get command line parameters
@@ -22,12 +23,13 @@ if __name__=='__main__':
     hptcut        = args.hptcut
     metcut        = args.metcut
     btagwp        = args.btagwp
+    year          = args.year
 
-    bkgfiles = go.gatherBkg('analysis_output_ZpAnomalon/'+args.date,'upout',zptcut,hptcut,metcut,btagwp)
+    bkgfiles = go.gatherBkg('analysis_output_ZpAnomalon/'+args.date,'upout',zptcut,hptcut,metcut,btagwp,year)
     #bkguncs  = np.load('analysis_output_ZpAnomalon/'+args.date+'/Fall17.AllZpAnomalonBkgs_unc_Zptcut'+str(zptcut)+'_Hptcut'+str(hptcut)+'_metcut'+str(metcut)+'_btagwp'+str(btagwp)+'.npz')
     bkgnames = ["DYJetsToLL","TT","WZTo2L2Q","ZZTo2L2Q"]
     bkgcols  = go.colsFromPalette(bkgnames,ROOT.kLake)
-    bkginfo  = go.prepBkg(bkgfiles,bkgnames,bkgcols,'xsects_2017.ini',lumi)#gathers xs scales
+    bkginfo  = go.prepBkg(bkgfiles,bkgnames,bkgcols,'xsects_2017.ini',lumi,"yes")#gathers xs scales
 
     metstr = "Percent Passing \(MET > "+str(metcut)+"\)"
     zptstr = "Percent Passing \(Z p_{T} > "+str(zptcut)+"\)"

--- a/doSelections.py
+++ b/doSelections.py
@@ -1,11 +1,11 @@
-import uproot4 as up4
-import uproot as up3
+import uproot as up4
+import uproot3 as up3
 import pandas as pd
 import numpy as np
 import boost_histogram as bh
 import argparse
 import glob
-import gecorg_py3 as go
+import gecorg as go
 
 parser = argparse.ArgumentParser()
 
@@ -75,14 +75,13 @@ if __name__=='__main__':
         lowsb  = btdf[btdf['hCandidate_sd'] <= 70.]
         highsb = btdf[btdf['hCandidate_sd'] >= 150.]
         sbdf   = pd.concat([lowsb,highsb])
-
         #btagging
         #btdf = srdf[srdf['hCandidate_'+btaggr] > float(btagwp)]
 
         #fdf is always the last dataframe
         #fdf = btdf
         if stype != 0:
-            fdf = btdf#all regio for soft drop mass plot
+            fdf = sbdf
         else:
             fdf = sbdf
 

--- a/doSelections.py
+++ b/doSelections.py
@@ -37,7 +37,8 @@ if __name__=='__main__':
     btagwp = args.btagWP
 
     #inputfiles = glob.glob('../RestFrames/analysis_output_ZpAnomalon/2020-12-29/'+samp+'*_topiary*.root')
-    inputfiles = glob.glob('../RestFrames/analysis_output_ZpAnomalon/'+args.date+'/'+samp+'*_topiary*.root')
+    #inputfiles = glob.glob('../RestFrames/analysis_output_ZpAnomalon/'+args.date+'/'+samp+'*_topiary*.root')
+    inputfiles = glob.glob('analysis_output_ZpAnomalon/'+args.date+'/'+samp+'*_topiary*.root')
     print("    Doing selections on:")
     print(inputfiles)
     stype,year = go.sampleType(samp)
@@ -58,6 +59,8 @@ if __name__=='__main__':
     events = up3.pandas.iterate(inputfiles[:1],'PreSelection;1',branches=branches)
 
 
+    #print(events['event_weight'])
+    
     #print(jets.ls))
     
     for b in events:

--- a/doSelections.py
+++ b/doSelections.py
@@ -38,9 +38,10 @@ if __name__=='__main__':
 
     #inputfiles = glob.glob('../RestFrames/analysis_output_ZpAnomalon/2020-12-29/'+samp+'*_topiary*.root')
     inputfiles = glob.glob('../RestFrames/analysis_output_ZpAnomalon/'+args.date+'/'+samp+'*_topiary*.root')
-    print("Doing selections on:")
+    print("    Doing selections on:")
     print(inputfiles)
-    stype = go.sampleType(samp)
+    stype,year = go.sampleType(samp)
+    print(stype)
     
     branches = [b'ZCandidate_*',
                 b'hCandidate_*',
@@ -76,17 +77,16 @@ if __name__=='__main__':
         sbdf   = pd.concat([lowsb,highsb])
 
         #btagging
-        btdf = srdf[srdf['hCandidate_'+btaggr] > float(btagwp)]
+        #btdf = srdf[srdf['hCandidate_'+btaggr] > float(btagwp)]
 
-        #print(hptdf)
         #fdf is always the last dataframe
-        #fdf = sbdf
+        #fdf = btdf
         if stype != 0:
-            fdf = sbdf
+            fdf = btdf#all regio for soft drop mass plot
         else:
             fdf = sbdf
 
-        print("number of passing events ",len(fdf))
+        print("    number of passing events ",len(fdf))
         #print("number of btag passing events ",len(btdf))
 
     #lets make some histograms.

--- a/doStackedUncertainty.py
+++ b/doStackedUncertainty.py
@@ -5,7 +5,7 @@ import gecorg_py3 as go
 import configparser
 import glob
 
-def saveUncertainties(uncdf,filename):
+def saveNpUncertainties(uncdf,filename):
     npF = open(filename,'wb')
     np.savez(npF,
              h_z_pt  = uncdf['h_z_pt'].values,
@@ -57,7 +57,7 @@ if __name__=='__main__':
         fp = open('xsects_2018.ini')
         mcprefix  = 'Aumtumn18'
         datprefix = 'Run2018'
-    config.readfp(fp)
+    config.read_file(fp)
     bkgdfs = {}
     for name in bkgnames:
         if name == "DYJetsToLL":
@@ -82,38 +82,44 @@ if __name__=='__main__':
     
     uncsqdDYJetsdf = sum(bkgdfs["DYJetsToLL"])
     uncDYJetsdf    = uncsqdDYJetsdf**(1/2)
-    saveDYJetsunc  = go.makeOutFile(mcprefix+'.DYJetsToLL','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
-    saveDYJetsuncCsv  = go.makeOutFile(mcprefix+'.DYJetsToLL','unc','.csv',str(zptcut),str(hptcut),str(metcut),str(btagwp))
-    saveUncertainties(uncDYJetsdf,saveDYJetsunc)
-    uncDYJetsdf.to_csv()
+    saveDYJetsNpunc  = go.makeOutFile(mcprefix+'.DYJetsToLL','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    saveNpUncertainties(uncDYJetsdf,saveDYJetsNpunc)
+    saveDYJetsunc  = go.makeOutFile(mcprefix+'.DYJetsToLL','unc','.pkl',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    uncDYJetsdf.to_pickle(saveDYJetsunc)
+    #saveDYJetsuncCsv  = go.makeOutFile(mcprefix+'.DYJetsToLL','unc','.csv',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+
+    #uncDYJetsdf.to_csv(saveDYJetsuncCsv)
     
     uncsqdTTdf     = sum(bkgdfs["TT"])
     uncTTdf        = uncsqdTTdf**(1/2)
-    saveTTunc      = go.makeOutFile(mcprefix+'.TT','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
-    saveUncertainties(uncTTdf,saveTTunc)
+    saveTTNpunc      = go.makeOutFile(mcprefix+'.TT','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    saveTTunc      = go.makeOutFile(mcprefix+'.TT','unc','.pkl',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    saveNpUncertainties(uncTTdf,saveTTNpunc)
+    uncTTdf.to_pickle(saveTTunc)
     
     uncsqdWZdf     = sum(bkgdfs["WZTo2L2Q"])
     uncWZdf        = uncsqdWZdf**(1/2)
-    saveWZ2L2Qunc  = go.makeOutFile(mcprefix+'.WZ2L2Q','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
-    saveUncertainties(uncWZdf,saveWZ2L2Qunc)
+    saveWZ2L2QNpunc  = go.makeOutFile(mcprefix+'.WZ2L2Q','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    saveWZ2L2Qunc  = go.makeOutFile(mcprefix+'.WZ2L2Q','unc','.pkl',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    saveNpUncertainties(uncWZdf,saveWZ2L2QNpunc)
+    uncWZdf.to_pickle(saveWZ2L2Qunc)
     
     uncsqdZZdf     = sum(bkgdfs["ZZTo2L2Q"])
     uncZZdf        = uncsqdZZdf**(1/2)
-    saveZZ2L2Qunc  = go.makeOutFile(mcprefix+'.ZZ2L2Q','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
-    saveUncertainties(uncZZdf,saveWZ2L2Qunc)
+    saveZZ2L2QNpunc  = go.makeOutFile(mcprefix+'.ZZ2L2Q','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    saveZZ2L2Qunc  = go.makeOutFile(mcprefix+'.ZZ2L2Q','unc','.pkl',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    saveNpUncertainties(uncZZdf,saveWZ2L2QNpunc)
+    uncZZdf.to_pickle(saveZZ2L2Qunc)
     
     #Combine all for stacks
     uncsqdAlldf    = uncsqdDYJetsdf+uncsqdTTdf+uncsqdWZdf+uncsqdZZdf
     uncAlldf       = uncsqdAlldf**(1/2)
-    saveAllBkgunc  = go.makeOutFile(mcprefix+'.AllZpAnomalonBkgs','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
-    saveUncertainties(uncAlldf,saveAllBkgunc)
-
-    
-    
+    saveAllBkgNpunc  = go.makeOutFile(mcprefix+'.AllZpAnomalonBkgs','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    saveNpUncertainties(uncAlldf,saveAllBkgNpunc)
 
     #will only work once move stacker to python3
-    #totalUncFile = go.makeOutFile('Fall17.AllZpAnomalonBkgs','unc','.pkl',str(zptcut),str(hptcut),str(metcut))
-    #uncAlldf.to_pickle(totalUncFile)
+    totalUncFile = go.makeOutFile('Fall17.AllZpAnomalonBkgs','unc','.pkl',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    uncAlldf.to_pickle(totalUncFile)
 
     #saving as a numpy zip file hard coded right now because no mistake goes unpunished.
     #stacker just needs to be moved to python three to fix this mess
@@ -154,21 +160,22 @@ if __name__=='__main__':
     datuncsum = sum(datadfs)
     datuncall = datuncsum**(1/2)
 
-    datFileName = go.makeOutFile(datprefix+'.AllZpAnomalonData','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    datFileName = go.makeOutFile(datprefix+'.AllZpAnomalonData','unc','.pkl',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    datuncall.to_pickle(datFileName)
 
-    npdatF = open(datFileName,'wb')
-    np.savez(npdatF,
-             h_z_pt  = datuncall['h_z_pt'].values,
-             h_z_eta = datuncall['h_z_eta'].values,
-             h_z_m   = datuncall['h_z_m'].values,
-             h_h_pt  = datuncall['h_h_pt'].values,
-             h_h_eta = datuncall['h_h_eta'].values,
-             h_h_m   = datuncall['h_h_m'].values,
-             h_h_sd  = datuncall['h_h_sd'].values,
-             h_met   = datuncall['h_met'].values,
-             h_zp_jigm = datuncall['h_zp_jigm'].values,
-             h_nd_jigm = datuncall['h_nd_jigm'].values,
-             h_ns_jigm = datuncall['h_ns_jigm'].values,
-             h_btag    = datuncall['h_btag'].values
-             )
+    #npdatF = open(datFileName,'wb')
+    #np.savez(npdatF,
+    #         h_z_pt  = datuncall['h_z_pt'].values,
+    #         h_z_eta = datuncall['h_z_eta'].values,
+    #         h_z_m   = datuncall['h_z_m'].values,
+    #         h_h_pt  = datuncall['h_h_pt'].values,
+    #         h_h_eta = datuncall['h_h_eta'].values,
+    #         h_h_m   = datuncall['h_h_m'].values,
+    #         h_h_sd  = datuncall['h_h_sd'].values,
+    #         h_met   = datuncall['h_met'].values,
+    #         h_zp_jigm = datuncall['h_zp_jigm'].values,
+    #         h_nd_jigm = datuncall['h_nd_jigm'].values,
+    #         h_ns_jigm = datuncall['h_ns_jigm'].values,
+    #         h_btag    = datuncall['h_btag'].values
+    #         )
 

--- a/doStackedUncertainty.py
+++ b/doStackedUncertainty.py
@@ -83,27 +83,30 @@ if __name__=='__main__':
     uncsqdDYJetsdf = sum(bkgdfs["DYJetsToLL"])
     uncDYJetsdf    = uncsqdDYJetsdf**(1/2)
     saveDYJetsunc  = go.makeOutFile(mcprefix+'.DYJetsToLL','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
-    print(uncDYJetsdf)
+    saveDYJetsuncCsv  = go.makeOutFile(mcprefix+'.DYJetsToLL','unc','.csv',str(zptcut),str(hptcut),str(metcut),str(btagwp))
     saveUncertainties(uncDYJetsdf,saveDYJetsunc)
+    uncDYJetsdf.to_csv()
     
-    #uncsqdTTdf     = sum(bkgdfs["TT"])
-    #uncTTdf        = uncsqdTTdf**(1/2)
-    #saveTTunc      = go.makeOutFile(mcprefix+'.TT','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
-    #saveUncertainties(uncTTdf,saveTTunc)
+    uncsqdTTdf     = sum(bkgdfs["TT"])
+    uncTTdf        = uncsqdTTdf**(1/2)
+    saveTTunc      = go.makeOutFile(mcprefix+'.TT','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    saveUncertainties(uncTTdf,saveTTunc)
     
-    #uncsqdWZdf     = sum(bkgdfs["WZTo2L2Q"])
-    #uncWZdf        = uncsqdWZdf**(1/2)
-    #saveWZ2L2Qunc  = go.makeOutFile(mcprefix+'.WZ2L2Q','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
-    #saveUncertainties(uncWZdf,saveWZ2L2Qunc)
+    uncsqdWZdf     = sum(bkgdfs["WZTo2L2Q"])
+    uncWZdf        = uncsqdWZdf**(1/2)
+    saveWZ2L2Qunc  = go.makeOutFile(mcprefix+'.WZ2L2Q','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    saveUncertainties(uncWZdf,saveWZ2L2Qunc)
     
-    #uncsqdZZdf     = sum(bkgdfs["ZZTo2L2Q"])
-    #uncZZdf        = uncsqdZZdf**(1/2)
-    #saveZZ2L2Qunc  = go.makeOutFile(mcprefix+'.ZZ2L2Q','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
-    #saveUncertainties(uncZZdf,saveWZ2L2Qunc)
+    uncsqdZZdf     = sum(bkgdfs["ZZTo2L2Q"])
+    uncZZdf        = uncsqdZZdf**(1/2)
+    saveZZ2L2Qunc  = go.makeOutFile(mcprefix+'.ZZ2L2Q','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    saveUncertainties(uncZZdf,saveWZ2L2Qunc)
     
     #Combine all for stacks
-    #uncsqdAlldf    = uncsqdDYJetsdf+uncsqdTTdf+uncsqdWZdf+uncsqdZZdf
-    #uncAlldf       = uncsqdAlldf**(1/2)
+    uncsqdAlldf    = uncsqdDYJetsdf+uncsqdTTdf+uncsqdWZdf+uncsqdZZdf
+    uncAlldf       = uncsqdAlldf**(1/2)
+    saveAllBkgunc  = go.makeOutFile(mcprefix+'.AllZpAnomalonBkgs','unc','.npz',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+    saveUncertainties(uncAlldf,saveAllBkgunc)
 
     
     
@@ -136,7 +139,7 @@ if __name__=='__main__':
     #Now, do the same for data. This can clearly be combined into a function of somekind,
     #but we need results now!
 
-    #datcountfs = glob.glob('analysis_output_ZpAnomalon/2021-01-14/Run2017*totalevents_Zptcut'+str(zptcut)+'_Hptcut'+str(hptcut)+'_metcut'+str(metcut)+'.npy')
+    datcountfs = glob.glob('analysis_output_ZpAnomalon/2021-01-14/Run2017*totalevents_Zptcut'+str(zptcut)+'_Hptcut'+str(hptcut)+'_metcut'+str(metcut)+'.npy')
     daterrfs = glob.glob('analysis_output_ZpAnomalon/'+args.date+'/'+datprefix+'*selected_errors*_Zptcut'+str(zptcut)+'_Hptcut'+str(hptcut)+'_metcut'+str(metcut)+'_btagwp'+str(btagwp)+'.pkl')
 
     datadfs = []

--- a/gecorg.py
+++ b/gecorg.py
@@ -11,6 +11,7 @@ def sampleType(sampstring):
         samptype = 0
     elif "ZpAnomalon" in sampstring:
         samptype = 1
+        year = 17
     elif "DYJetsToLL" in sampstring:
          samptype = 2
     elif "TTTo" in sampstring:
@@ -80,7 +81,7 @@ def colsFromPalette(samplist,palname):
     return collist
 
 def gatherBkg(bkg_dir,descrip,zptcut,hptcut,metcut,btagwp,year):
-        if year == 18:
+    if year == 18:
         mcprefix = 'Autumn18'
     if year == 17:
         mcprefix = 'Fall17'
@@ -113,7 +114,7 @@ def prepSig(sigfiles,sig_colors,sig_xsec,lumi):
 
     return sig_info
 
-def prepBkg(bkgfiles,bkgnames,bkg_colors,ini_file,lumi):
+def prepBkg(bkgfiles,bkgnames,bkg_colors,ini_file,lumi,flag):
     config = ConfigParser.RawConfigParser()
     config.optionxform = str
     fp = open(ini_file)
@@ -132,6 +133,9 @@ def prepBkg(bkgfiles,bkgnames,bkg_colors,ini_file,lumi):
         if bkg_channel == "DYJetsToLL":
             #orders smallest HT to largest
             bkg.sort(key = orderFall17DY)
+        else:
+            if flag == "no":
+                break
         #elif bkg_channel == "TT":
             #orders smallest # events (xs) to largest
         #    bkg.sort(key = orderFall17TT)                                                     

--- a/gecorg_py2.py
+++ b/gecorg_py2.py
@@ -2,7 +2,7 @@ import os
 import sys
 import glob
 import ROOT
-import configparser
+import ConfigParser
 from datetime import date
 
 def sampleType(sampstring):
@@ -22,7 +22,7 @@ def sampleType(sampstring):
         samptype = 5
     else:
         samptype = -1
-
+        
     if "2018" in sampstring:
         year = 18
     if "Autumn18" in sampstring:
@@ -42,7 +42,7 @@ def makeOutFile(sampstring,descrip,ftype,zptcut,hptcut,metcut,btagwp):
     outFile = "analysis_output_ZpAnomalon/"+str(date.today())+"/"+sampstring+"_"+descrip+"_Zptcut"+zptcut+"_Hptcut"+hptcut+"_metcut"+metcut+"_btagwp"+btagwp+ftype
     return outFile
 
-def orderDY(histFile):
+def orderFall17DY(histFile):
     s1 = histFile.split("to")[0]
     s2 = s1.split("HT-")[1]
     return int(s2)       
@@ -77,7 +77,7 @@ def colsFromPalette(samplist,palname):
     cols = ROOT.TColor.GetPalette()
     colsnum = cols.GetSize()
     for i in range(len(samplist)):
-        collist.append(cols.At(0+i*int(colsnum/len(samplist))))
+        collist.append(cols.At(0+i*colsnum/len(samplist)))
     return collist
 
 def gatherBkg(bkg_dir,descrip,zptcut,hptcut,metcut,btagwp,year):
@@ -85,7 +85,7 @@ def gatherBkg(bkg_dir,descrip,zptcut,hptcut,metcut,btagwp,year):
         mcprefix = 'Autumn18'
     if year == 17:
         mcprefix = 'Fall17'
-        
+
     DYJetsToLL = glob.glob(str(bkg_dir)+'/'+mcprefix+'.DYJetsToLL_M-50_HT*'+descrip+'*_Zptcut'+str(zptcut)+'_Hptcut'+str(hptcut)+'_metcut'+str(metcut)+'_btagwp'+str(btagwp)+'*')
     TT         = glob.glob(str(bkg_dir)+'/'+mcprefix+'.TTT*_'+descrip+'*_Zptcut'+str(zptcut)+'_Hptcut'+str(hptcut)+'_metcut'+str(metcut)+'_btagwp'+str(btagwp)+'*')                                         
     WZTo2L2Q   = glob.glob(str(bkg_dir)+'/'+mcprefix+'.WZTo2L2Q*'+descrip+'*_Zptcut'+str(zptcut)+'_Hptcut'+str(hptcut)+'_metcut'+str(metcut)+'_btagwp'+str(btagwp)+'*')                                    
@@ -102,10 +102,11 @@ def prepSig(sigfiles,sig_colors,sig_xsec,lumi):
         sig_dict["scale"] = findScale(float(sig_samplesize),sig_xsec,lumi)
         sig_dict["name"]  = nameSignal(sig)
         mzp,mnd,mns       = massPoints(sig_dict["name"])
-        sig_dict["mzp"]   = mzp#
+        sig_dict["mzp"]   = mzp
         sig_dict["mnd"]   = mnd
         sig_dict["mns"]   = mns
-        sig_info.append(sig_dict)                                                                    
+        sig_info.append(sig_dict)                                                                       
+                                                                                                        
     #Sort Signals by ND mass, then by Zp mass                                                           
     sig_info = sorted(sig_info,key = lambda sig: (sig["mnd"],sig["mzp"],sig["mns"]))                    
     for s,sig in enumerate(sig_info):                                                                   
@@ -114,12 +115,13 @@ def prepSig(sigfiles,sig_colors,sig_xsec,lumi):
     return sig_info
 
 def prepBkg(bkgfiles,bkgnames,bkg_colors,ini_file,lumi,flag):
-    config = configparser.RawConfigParser()
+    config = ConfigParser.RawConfigParser()
     config.optionxform = str
     fp = open(ini_file)
-    config.read_file(fp)
+    config.readfp(fp)
     bkg_info = []
     for b,bkg in enumerate(bkgfiles):
+        #print bkg
         bkg_binsum   = {}
         bkg_binlist  = []
         
@@ -127,9 +129,10 @@ def prepBkg(bkgfiles,bkgnames,bkg_colors,ini_file,lumi,flag):
         bkg_expyield = 0
         # bkg xs from .ini file
         bkgbin_xs_pairs = config.items(bkg_channel)
+        #print bkgbin_xs_pairs
         if bkg_channel == "DYJetsToLL":
             #orders smallest HT to largest
-            bkg.sort(key = orderDY)
+            bkg.sort(key = orderFall17DY)
         else:
             if flag == "no":
                 break
@@ -158,21 +161,21 @@ def prepBkg(bkgfiles,bkgnames,bkg_colors,ini_file,lumi,flag):
     #Sort the backgrounds from the smallest yields to largest        
     bkg_info = sorted(bkg_info, key = lambda bkg:bkg["expyield"])
     return bkg_info
-#
+
 def stackBkg(bkg_info,hist_to_stack,hsbkg,legend,stack_max,stack_min):
     for bkg in bkg_info:
         for b,bkgbin in enumerate(bkg["binlist"]):
             hbkg = bkgbin["tfile"].Get(hist_to_stack)
             hbkg.SetStats(0)
             hbkg.Scale(bkgbin["scale"])
-            hbkg.SetFillColor(bkgbin["color"])
-            hbkg.SetLineColor(bkgbin["color"])
+            hbkg.SetFillColor(bkgbin["color"])                                                          
+            hbkg.SetLineColor(bkgbin["color"])                                                          
             hbkg.SetMaximum(stack_max)
             hbkg.SetMinimum(stack_min)
-            hsbkg.Add(hbkg)
-            hsbkg.Draw("HIST")
+            hsbkg.Add(hbkg)                                                                             
+            hsbkg.Draw("HIST")                                                                          
             hsbkg.SetMaximum(stack_max)
             hsbkg.SetMinimum(stack_min)
-            if b == len(bkg["binlist"])-1:
+            if b == len(bkg["binlist"])-1:                                                              
                 legend.AddEntry(hbkg,bkg["name"],"f")
 

--- a/gecorg_py3.py
+++ b/gecorg_py3.py
@@ -36,7 +36,6 @@ def sampleType(sampstring):
 
     return samptype,year
 
-
 def makeOutFile(sampstring,descrip,ftype,zptcut,hptcut,metcut,btagwp):
     if not os.path.exists("analysis_output_ZpAnomalon/"+str(date.today())+"/"):
         os.makedirs("analysis_output_ZpAnomalon/"+str(date.today())+"/")
@@ -166,14 +165,14 @@ def stackBkg(bkg_info,hist_to_stack,hsbkg,legend,stack_max,stack_min):
             hbkg = bkgbin["tfile"].Get(hist_to_stack)
             hbkg.SetStats(0)
             hbkg.Scale(bkgbin["scale"])
-            hbkg.SetFillColor(bkgbin["color"])                                                          
-            hbkg.SetLineColor(bkgbin["color"])                                                         
+            hbkg.SetFillColor(bkgbin["color"])
+            hbkg.SetLineColor(bkgbin["color"])
             hbkg.SetMaximum(stack_max)
             hbkg.SetMinimum(stack_min)
-            hsbkg.Add(hbkg)                                                                             
-            hsbkg.Draw("HIST")                                                                          
+            hsbkg.Add(hbkg)
+            hsbkg.Draw("HIST")
             hsbkg.SetMaximum(stack_max)
             hsbkg.SetMinimum(stack_min)
-            if b == len(bkg["binlist"])-1:                                                              
+            if b == len(bkg["binlist"])-1:
                 legend.AddEntry(hbkg,bkg["name"],"f")
 

--- a/runSelectionsToPlots.py
+++ b/runSelectionsToPlots.py
@@ -6,7 +6,7 @@ if __name__=='__main__':
     #steps to run
     #assumes you have run the whole thing at the start of the day
     #steps = {"selections":True,"uncs":True,"ratios":True,"opts":True}
-    steps = {"selections":False,"uncs":False,"ratios":True,"opts":False,"cutflow":False}
+    steps = {"selections":True,"uncs":True,"ratios":True,"opts":True,"cutflow":True}
     
     #cut list, Zpt, Hpt, met,btagger,btagwp
     cutlist = [['200.0','300.0','300.0','DeepMassDecorrelTagZHbbvsQCD','0.8'],
@@ -78,7 +78,7 @@ if __name__=='__main__':
             #Optimization Plots
             if steps["opts"]:
                 for plot in plots:
-                    subprocess.run(["python2","stackForOptimization.py","-L",era[1],"-x","10`0.0","-p",plot,"-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",str(date.today()),"-y",era[0]])
+                    subprocess.run(["python","stackForOptimization.py","-L",era[1],"-x","10.0","-p",plot,"-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",str(date.today()),"-y",era[0]])
                 #subprocess.run(["python","stackForOptimization.py","-L",lumi,"-x","100.0","-p",plot,"-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",'2021-02-03'])
 
             if steps["cutflow"]:

--- a/runSelectionsToPlots.py
+++ b/runSelectionsToPlots.py
@@ -6,7 +6,7 @@ if __name__=='__main__':
     #steps to run
     #assumes you have run the whole thing at the start of the day
     #steps = {"selections":True,"uncs":True,"ratios":True,"opts":True}
-    steps = {"selections":True,"uncs":True,"ratios":False,"opts":False,"cutflow":False}
+    steps = {"selections":True,"uncs":True,"ratios":True,"opts":False,"cutflow":False}
     
     #cut list, Zpt, Hpt, met,btagger,btagwp
     cutlist = [['200.0','300.0','300.0','DeepMassDecorrelTagZHbbvsQCD','0.8'],
@@ -17,15 +17,15 @@ if __name__=='__main__':
 
     #year specifics, year as 2 digit end, integrated luminosity
     eras = [["17","41.53"],
-            ["18","59.74"]
+            #["18","59.74"]
             ]
 
     plots = ['h_h_pt','h_z_pt','h_met','h_nd_jigm','h_zp_jigm','h_h_sd','h_btag']
 
     #topiary sample list: dateforfolder, samplename
-    samplelist = [#['2020-12-29','Fall17.TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_new_pmx'],
-                  #['2020-12-29','Fall17.WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8'],
-                  #['2020-12-29','Fall17.ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8'],
+    samplelist = [['2021-02-25','Fall17.TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_new_pmx'],
+                  ['2021-02-25','Fall17.WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8'],
+                  ['2021-02-25','Fall17.ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8'],
                   #['2020-12-29','ZpAnomalonHZ_UFO-Zp1200-ND175-NS1'],
                   #['2020-12-29','ZpAnomalonHZ_UFO-Zp2000-ND175-NS1'],
                   #['2020-12-29','ZpAnomalonHZ_UFO-Zp2000-ND300-NS1'],
@@ -50,16 +50,16 @@ if __name__=='__main__':
                   ['2021-02-24','Fall17.DYJetsToLL_M-50_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8'],
                   ['2021-02-24','Fall17.DYJetsToLL_M-50_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8'],
                   ['2021-02-24','Fall17.DYJetsToLL_M-50_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8'],
-                  ['2021-02-24','Run2018C-17Sep2018-v1.SingleMuon'],
-                  ['2021-02-24','Run2018B-17Sep2018-v1.SingleMuon'],
-                  ['2021-02-24','Run2018A-17Sep2018-v1.SingleMuon'],
-                  ['2021-02-24','Autumn18.DYJetsToLL_M-50_HT-100to200_TuneCP5_PSweights_13TeV-madgraphMLM-pythia'],
-                  ['2021-02-24','Autumn18.DYJetsToLL_M-50_HT-200to400_TuneCP5_PSweights_13TeV-madgraphMLM-pythia'],
-                  ['2021-02-24','Autumn18.DYJetsToLL_M-50_HT-400to600_TuneCP5_PSweights_13TeV-madgraphMLM-pythia'],
-                  ['2021-02-24','Autumn18.DYJetsToLL_M-50_HT-600to800_TuneCP5_PSweights_13TeV-madgraphMLM-pythia'],
-                  ['2021-02-24','Autumn18.DYJetsToLL_M-50_HT-800to1200_TuneCP5_PSweights_13TeV-madgraphMLM-pythia'],
-                  ['2021-02-24','Autumn18.DYJetsToLL_M-50_HT-1200to2500_TuneCP5_PSweights_13TeV-madgraphMLM-pythia'],
-                  ['2021-02-24','Autumn18.DYJetsToLL_M-50_HT-2500toInf_TuneCP5_PSweights_13TeV-madgraphMLM-pythia'],
+                  #['2021-02-24','Run2018C-17Sep2018-v1.SingleMuon'],
+                  #['2021-02-24','Run2018B-17Sep2018-v1.SingleMuon'],
+                  #['2021-02-24','Run2018A-17Sep2018-v1.SingleMuon'],
+                  #['2021-02-24','Autumn18.DYJetsToLL_M-50_HT-100to200_TuneCP5_PSweights_13TeV-madgraphMLM-pythia'],
+                  #['2021-02-24','Autumn18.DYJetsToLL_M-50_HT-200to400_TuneCP5_PSweights_13TeV-madgraphMLM-pythia'],
+                  #['2021-02-24','Autumn18.DYJetsToLL_M-50_HT-400to600_TuneCP5_PSweights_13TeV-madgraphMLM-pythia'],
+                  #['2021-02-24','Autumn18.DYJetsToLL_M-50_HT-600to800_TuneCP5_PSweights_13TeV-madgraphMLM-pythia'],
+                  #['2021-02-24','Autumn18.DYJetsToLL_M-50_HT-800to1200_TuneCP5_PSweights_13TeV-madgraphMLM-pythia'],
+                  #['2021-02-24','Autumn18.DYJetsToLL_M-50_HT-1200to2500_TuneCP5_PSweights_13TeV-madgraphMLM-pythia'],
+                  #['2021-02-24','Autumn18.DYJetsToLL_M-50_HT-2500toInf_TuneCP5_PSweights_13TeV-madgraphMLM-pythia'],
                   ]
     
     for cut in cutlist:
@@ -77,6 +77,7 @@ if __name__=='__main__':
             #stack all  
             if steps["ratios"]:
                 subprocess.run(["python","stackAll.py","-L",era[1],"-x","10.0","-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",str(date.today()),"-y",era[0]])
+                #subprocess.run(["python","stackAll.py","-L","41.53","-x","10.0","-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",str(date.today()),"-y","17")
                 #subprocess.run(["python","stackAll.py","-L",lumi,"-x","10.0","-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",str(date.today())+'/signalregion_only/'])
 
             #Optimization Plots

--- a/runSelectionsToPlots.py
+++ b/runSelectionsToPlots.py
@@ -6,11 +6,11 @@ if __name__=='__main__':
     #steps to run
     #assumes you have run the whole thing at the start of the day
     #steps = {"selections":True,"uncs":True,"ratios":True,"opts":True}
-    steps = {"selections":True,"uncs":True,"ratios":True,"opts":False,"cutflow":False}
+    steps = {"selections":False,"uncs":False,"ratios":True,"opts":False,"cutflow":False}
     
     #cut list, Zpt, Hpt, met,btagger,btagwp
     cutlist = [['200.0','300.0','300.0','DeepMassDecorrelTagZHbbvsQCD','0.8'],
-               ['150.0','300.0','100.0','DeepMassDecorrelTagZHbbvsQCD','0.8'],
+               #['150.0','300.0','100.0','DeepMassDecorrelTagZHbbvsQCD','0.8'],
                ]
 
     lumi = "41.53"
@@ -26,18 +26,13 @@ if __name__=='__main__':
     samplelist = [['2021-02-25','Fall17.TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_new_pmx'],
                   ['2021-02-25','Fall17.WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8'],
                   ['2021-02-25','Fall17.ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8'],
-                  #['2020-12-29','ZpAnomalonHZ_UFO-Zp1200-ND175-NS1'],
+                  ['2021-02-26','ZpAnomalonHZ_UFO-Zp1200-ND175-NS1'],
                   #['2020-12-29','ZpAnomalonHZ_UFO-Zp2000-ND175-NS1'],
-                  #['2020-12-29','ZpAnomalonHZ_UFO-Zp2000-ND300-NS1'],
+                  ['2021-02-26','ZpAnomalonHZ_UFO-Zp2000-ND300-NS1'],
                   #['2020-12-29','ZpAnomalonHZ_UFO-Zp2000-ND500-NS200'],
-                  #['2020-12-29','ZpAnomalonHZ_UFO-Zp2000-ND800-NS200'],
+                  ['2021-02-26','ZpAnomalonHZ_UFO-Zp2000-ND800-NS200'],
                   #['2020-12-29','ZpAnomalonHZ_UFO-Zp3000-ND1200-NS1'],
-                  #['2020-12-29','ZpAnomalonHZ_UFO-Zp3000-ND500-NS1'],
-                  #['2021-01-05','Run2017B-31Mar2018-v1.SingleMuon'],
-                  #['2021-01-05','Run2017C-31Mar2018-v1.SingleMuon'],
-                  #['2021-01-05','Run2017D-31Mar2018-v1.SingleMuon'],
-                  #['2021-01-05','Run2017E-31Mar2018-v1.SingleMuon'],
-                  #['2021-01-05','Run2017F-31Mar2018-v1.SingleMuon'],
+                  #['2021-02-26','ZpAnomalonHZ_UFO-Zp3000-ND500-NS1'],
                   ['2021-02-24','Run2017B-31Mar2018-v1.SingleMuon'],
                   ['2021-02-24','Run2017C-31Mar2018-v1.SingleMuon'],
                   ['2021-02-24','Run2017D-31Mar2018-v1.SingleMuon'],
@@ -67,12 +62,12 @@ if __name__=='__main__':
         #do selections
         if steps["selections"]:
             for samp in samplelist:
-                subprocess.run(["python3","doSelections.py","-f",samp[1],"-zpt",cut[0],"-hpt",cut[1],"-met",cut[2],"-sdm","30.0","-b",cut[3],"-wp",cut[4],"-date",samp[0]])
+                subprocess.run(["python","doSelections.py","-f",samp[1],"-zpt",cut[0],"-hpt",cut[1],"-met",cut[2],"-sdm","30.0","-b",cut[3],"-wp",cut[4],"-date",samp[0]])
 
         for era in eras:
             print("   Beginning plottng and analysis for year {0}, with a luminosity of {1}".format(era[0],era[1]))
             if steps["uncs"]:
-                subprocess.run(["python3","doStackedUncertainty.py","-L",era[1],"-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",str(date.today()),"-y",era[0]])
+                subprocess.run(["python","doStackedUncertainty.py","-L",era[1],"-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",str(date.today()),"-y",era[0]])
 
             #stack all  
             if steps["ratios"]:
@@ -83,10 +78,10 @@ if __name__=='__main__':
             #Optimization Plots
             if steps["opts"]:
                 for plot in plots:
-                    subprocess.run(["python","stackForOptimization.py","-L",era[1],"-x","10`0.0","-p",plot,"-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",str(date.today()),"-y",era[0]])
+                    subprocess.run(["python2","stackForOptimization.py","-L",era[1],"-x","10`0.0","-p",plot,"-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",str(date.today()),"-y",era[0]])
                 #subprocess.run(["python","stackForOptimization.py","-L",lumi,"-x","100.0","-p",plot,"-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",'2021-02-03'])
 
             if steps["cutflow"]:
                 print("Creating cutflow table")
-                subprocess.run(["python","doCutFlow.py","-L",era[1],"-x","10.0","-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",str(date.today()),"-y",era[0]])
+                subprocess.run(["python2","doCutFlow.py","-L",era[1],"-x","10.0","-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",str(date.today()),"-y",era[0]])
             

--- a/runSelectionsToPlots.py
+++ b/runSelectionsToPlots.py
@@ -83,5 +83,5 @@ if __name__=='__main__':
 
             if steps["cutflow"]:
                 print("Creating cutflow table")
-                subprocess.run(["python2","doCutFlow.py","-L",era[1],"-x","10.0","-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",str(date.today()),"-y",era[0]])
+                subprocess.run(["python","doCutFlow.py","-L",era[1],"-x","10.0","-m",cut[2],"-z",cut[0],"-j",cut[1],"-wp",cut[4],"-date",str(date.today()),"-y",era[0]])
             

--- a/runTopiary.py
+++ b/runTopiary.py
@@ -16,10 +16,11 @@ if __name__=="__main__":
     year = args.year
     samptype = -1
 
-    print samp
     samptype,checkedyear = go.sampleType(samp)
+    #samptype = 1
+    #checkedyear = 17
     if samptype < 0:
-        print "You have a problem, we do not undertand the sample coding"
+        print("You have a problem, we do not undertand the sample coding")
 
     origevnts = 0
     
@@ -36,12 +37,12 @@ if __name__=="__main__":
         origevnts = inChain.GetEntries()
 
     outFile = go.makeOutFile(samp,'topiary','.root','0.0','250.0','0.0','0.0')#Needs to become dynamic with cuts
-    print "Making topiary of ",samp
-    print "     Sample type ",samptype
-    print "     Sample Year ",year,checkedyear
-    print "     Events in TChain: ",inChain.GetEntries()
-    print ("     Original data set had {0} events in type.").format(origevnts)
-    print "    Saving topiary in ",outFile
+    print( "Making topiary of ",samp)
+    print("     Sample type ",samptype)
+    print("     Sample Year ",checkedyear)
+    print("     Events in TChain: ",inChain.GetEntries())
+    print(("     Original data set had {0} events in type.").format(origevnts))
+    print("    Saving topiary in ",outFile)
 
 
     ROOT.gSystem.CompileMacro("TreeMakerTopiary.C","g0ck")

--- a/stackAll.py
+++ b/stackAll.py
@@ -2,7 +2,9 @@ import argparse
 import ROOT
 import glob
 import os
-import gecorg
+#import gecorg_composite as gecorg
+import gecorg_py3 as gecorg
+import pandas as pd
 import numpy as np
 from datetime import date
 from ROOT import kOrange, kViolet, kCyan, kGreen, kPink, kAzure, kMagenta, kBlue, kBird
@@ -34,11 +36,15 @@ if __name__=='__main__':
 
     #samples
     bkgfiles = gecorg.gatherBkg('analysis_output_ZpAnomalon/'+args.date+'/','upout',zptcut,hptcut,metcut,btagwp,year)#recalculated ones with errrors
+    mcprefix = 'Autumn18'
+    descrip = 'upout'
+    
     bkgnames = ["DYJetsToLL","TT","WZTo2L2Q","ZZTo2L2Q"]
     sigfiles = glob.glob('analysis_output_ZpAnomalon/'+args.date+'/Zp*_upout*_Zptcut'+str(zptcut)+'_Hptcut'+str(hptcut)+'_metcut'+str(metcut)+'_btagwp'+str(btagwp)+'.root')#not changed for new naming yet
     datfiles = glob.glob('analysis_output_ZpAnomalon/'+args.date+'/Run2017*upout*_Zptcut'+str(zptcut)+'_Hptcut'+str(hptcut)+'_metcut'+str(metcut)+'_btagwp'+str(btagwp)+'.root')#not changed for new naming yet
-    #bkguncs  = np.load('analysis_output_ZpAnomalon/'+args.date+'/Fall17.AllZpAnomalonBkgs_unc_Zptcut'+str(zptcut)+'_Hptcut'+str(hptcut)+'_metcut'+str(metcut)+'_btagwp'+str(btagwp)+'.npz')
-    #datuncs  = np.load('analysis_output_ZpAnomalon/'+args.date+'/Run2017.AllZpAnomalonData_unc_Zptcut'+str(zptcut)+'_Hptcut'+str(hptcut)+'_metcut'+str(metcut)+'_btagwp'+str(btagwp)+'.npz')
+    
+    bkguncs  = pd.read_pickle('analysis_output_ZpAnomalon/'+args.date+'/Fall17.AllZpAnomalonBkgs_unc_Zptcut'+str(zptcut)+'_Hptcut'+str(hptcut)+'_metcut'+str(metcut)+'_btagwp'+str(btagwp)+'.pkl')
+    datuncs  =pd.read_pickle('analysis_output_ZpAnomalon/'+args.date+'/Run2017.AllZpAnomalonData_unc_Zptcut'+str(zptcut)+'_Hptcut'+str(hptcut)+'_metcut'+str(metcut)+'_btagwp'+str(btagwp)+'.pkl')
 
     #Prep signals
     sig_colors = gecorg.colsFromPalette(sigfiles,ROOT.kCMYK)
@@ -50,6 +56,7 @@ if __name__=='__main__':
 
     #Prep Data
     dat_info = [ROOT.TFile(dat) for dat in datfiles]
+    print(dat_info)
 
     #some beauty stuff
     max_plot = 100.
@@ -131,7 +138,7 @@ if __name__=='__main__':
         hsbkg.GetXaxis().SetTitleSize(0.05)
         hsbkg.GetYaxis().SetTitle("Events")
         hsbkg.GetYaxis().SetTitleSize(0.05)
-        hsdat.Draw("HISTSAMEPE")
+        #hsdat.Draw("HISTSAMEPE")
 
         #if 'h_h_sd' in hname:
         #    l0.Draw()
@@ -226,8 +233,8 @@ if __name__=='__main__':
         mg.SetMinimum(0.5)
         mg.SetMaximum(ratio_max)
         mg.SetMaximum(1.5)
-        mg.Draw("AP")
-        l.Draw()
+        #mg.Draw("AP")
+        #l.Draw()
         
         #Go back to previous pad so next kinematic plots draw
         tc.cd()
@@ -243,5 +250,5 @@ if __name__=='__main__':
         leg.Draw()
 
         #Save the plot
-        pngname = gecorg.makeOutFile(hname,'ratio','.png',str(zptcut),str(hptcut),str(metcut),str(btagwp))
+        pngname = gecorg.makeOutFile(hname,'ratio_2018','.png',str(zptcut),str(hptcut),str(metcut),str(btagwp))
         tc.SaveAs(pngname)

--- a/stackAll.py
+++ b/stackAll.py
@@ -138,7 +138,7 @@ if __name__=='__main__':
         hsbkg.GetXaxis().SetTitleSize(0.05)
         hsbkg.GetYaxis().SetTitle("Events")
         hsbkg.GetYaxis().SetTitleSize(0.05)
-        #hsdat.Draw("HISTSAMEPE")
+        hsdat.Draw("HISTSAMEPE")
 
         #if 'h_h_sd' in hname:
         #    l0.Draw()
@@ -172,26 +172,27 @@ if __name__=='__main__':
             bincen = hsumb.GetBinCenter(ibin)
             bkgmc  = hsumb.GetBinContent(ibin)
             data   = hsdat.GetBinContent(ibin)
-            #datunc = datuncs[hname][ibin-1]
+            #
             binlist[ibin] = bincen
             if ibin != 0:
-                #hsdat.SetBinError(ibin,datuncs[hname][ibin-1])
+                hsdat.SetBinError(ibin,datuncs[hname][ibin-1])
+                datunc = datuncs[hname][ibin-1]
                 if bkgmc != 0 and data != 0:
                     ratiolist[ibin] = data/bkgmc
                     #pulllist[ibin]  = (data-bkgmc)/datunc
                     #rerrlist[ibin] = datunc/bkgmc
-                    #rerrlist[ibin] = data/bkgmc*sqrt((datunc/data)**2+(bkguncs[hname][ibin-1]/bkgmc)**2)
+                    rerrlist[ibin] = data/bkgmc*sqrt((datunc/data)**2+(bkguncs[hname][ibin-1]/bkgmc)**2)
                 if bkgmc == 0:
                     ratiolist[ibin] = -1
-                    #rerrlist[ibin] = 0
+                    rerrlist[ibin] = 0
             else:
                 ratiolist[ibin] = -1
-                #rerrlist[ibin] = 0
+                rerrlist[ibin] = 0
         
         #remove underflow bin#hopefuly can get rid of this
         ratiolist = np.delete(ratiolist,0)
         binlist   = np.delete(binlist,0)
-        #rerrlist  = np.delete(rerrlist,0)
+        rerrlist  = np.delete(rerrlist,0)
 
         #Build the graphs
         tg = ROOT.TGraphErrors((hsumb.GetNbinsX()-1),binlist,ratiolist,fill,rerrlist)
@@ -219,7 +220,7 @@ if __name__=='__main__':
         else:
             ratio_max = max_max
         
-        #mg.SetTitle("")
+        mg.SetTitle("")
         #x axis
         mg.GetXaxis().SetTitle("bin center")
         mg.GetXaxis().SetTitleSize(0.07)
@@ -233,8 +234,8 @@ if __name__=='__main__':
         mg.SetMinimum(0.5)
         mg.SetMaximum(ratio_max)
         mg.SetMaximum(1.5)
-        #mg.Draw("AP")
-        #l.Draw()
+        mg.Draw("AP")
+        l.Draw()
         
         #Go back to previous pad so next kinematic plots draw
         tc.cd()

--- a/stackAll.py
+++ b/stackAll.py
@@ -3,7 +3,7 @@ import ROOT
 import glob
 import os
 #import gecorg_composite as gecorg
-import gecorg_py3 as gecorg
+import gecorg as gecorg
 import pandas as pd
 import numpy as np
 from datetime import date

--- a/stackForOptimization.py
+++ b/stackForOptimization.py
@@ -21,6 +21,7 @@ if __name__=='__main__':
     parser.add_argument("-j","--hptcut", type=float,help = "hpt cut of samples")
     parser.add_argument("-date","--date",help="date folder with plots to stack")
     parser.add_argument("-wp","--btagwp", type=float,help = "btag working point")
+    parser.add_argument("-y","--year", type=float,help = "year of samples eg. 2017 -> 17")
     args = parser.parse_args()
 
     #Get command line parameters
@@ -31,9 +32,10 @@ if __name__=='__main__':
     hptcut        = args.hptcut
     metcut        = args.metcut
     btagwp        = args.btagwp
-    plotmax       = 1000.0
+    year          = args.year
+    plotmax       = 100.0
     #Samples
-    bkgfiles = gecorg.gatherBkg('analysis_output_ZpAnomalon/'+args.date+'/','upout',zptcut,hptcut,metcut,btagwp)
+    bkgfiles = gecorg.gatherBkg('analysis_output_ZpAnomalon/'+args.date+'/','upout',zptcut,hptcut,metcut,btagwp,year)
     bkgnames = ["DYJetsToLL","TT","WZTo2L2Q","ZZTo2L2Q"]
     sigfiles = glob.glob('analysis_output_ZpAnomalon/'+args.date+'/Zp*_Zptcut'+str(zptcut)+'_Hptcut'+str(hptcut)+'_metcut'+str(metcut)+'_btagwp'+str(btagwp)+'.root')
 
@@ -60,6 +62,7 @@ if __name__=='__main__':
         "h_met":"pT miss",
         "h_zp_jigm":"Jigsaw Mass Estimator Z'",
         "h_nd_jigm":"Jigsaw Mass Estimator ND",
+        "h_btag":"btag point"
         }
 
     #Make a multigraph

--- a/stackForOptimization.py
+++ b/stackForOptimization.py
@@ -2,7 +2,7 @@ import argparse
 import ROOT
 import glob
 import os
-import gecorg
+import gecorg_py3 as gecorg
 import numpy as np
 from datetime import date
 from ROOT import kOrange, kViolet, kCyan, kGreen, kPink, kAzure, kMagenta, kBlue, kBird
@@ -45,7 +45,7 @@ if __name__=='__main__':
 
     #Prep backgrounds
     bkg_colors = gecorg.colsFromPalette(bkgnames,ROOT.kLake)
-    bkg_info   = gecorg.prepBkg(bkgfiles,bkgnames,bkg_colors,'xsects_2017.ini',lumi)
+    bkg_info   = gecorg.prepBkg(bkgfiles,bkgnames,bkg_colors,'xsects_2017.ini',lumi,"yes")
     #Make the stacked plot
     hname = released_plot
     leg = ROOT.TLegend(0.45,0.55,0.90,0.88)

--- a/stackForOptimization.py
+++ b/stackForOptimization.py
@@ -2,7 +2,7 @@ import argparse
 import ROOT
 import glob
 import os
-import gecorg_py3 as gecorg
+import gecorg
 import numpy as np
 from datetime import date
 from ROOT import kOrange, kViolet, kCyan, kGreen, kPink, kAzure, kMagenta, kBlue, kBird


### PR DESCRIPTION
This should move everything necessary except doAlphaMethod (which I will soon deprecate) to python 3, using the environment described in our new readme. This also fixes a weight issue (they were missed in the Topiary_MC and Topiary_Data move)